### PR TITLE
Add missing ReturnFrom to the StateBuilder

### DIFF
--- a/_posts/2015-07-09-monadster-3.md
+++ b/_posts/2015-07-09-monadster-3.md
@@ -556,6 +556,7 @@ Anyway, with those basics in place we can create a `state` expression.
 ```fsharp
 type StateBuilder()=
     member this.Return(x) = returnS x
+    member this.ReturnFrom(xS) = xS
     member this.Bind(xS,f) = bindS f xS
 
 let state = new StateBuilder()


### PR DESCRIPTION
Adding `ReturnFrom` to the `StateBuilder` because an example below
related to the heart creation contains `state` expression which uses
`return!` instruction. The corresponding gist example contains
`ReturnFrom` correctly.