### PR TITLE
fix(posts): annotate TryParse parameter in active patterns post

### DIFF
--- a/_posts/2012-04-17-convenience-active-patterns.md
+++ b/_posts/2012-04-17-convenience-active-patterns.md
@@ -15,13 +15,13 @@ Here is an example of using active patterns to parse a string into an int or boo
 ```fsharp
 // create an active pattern
 let (|Int|_|) str =
-   match System.Int32.TryParse(str) with
+   match System.Int32.TryParse(str:string) with
    | (true,int) -> Some(int)
    | _ -> None
 
 // create an active pattern
 let (|Bool|_|) str =
-   match System.Boolean.TryParse(str) with
+   match System.Boolean.TryParse(str:string) with
    | (true,bool) -> Some(bool)
    | _ -> None
 ```   


### PR DESCRIPTION
Thank you for your work on this site. I'm a newcomer to F# and it is an invaluable resource :)

While working through the "Why use F#?" series I encountered an error on the active patterns article. 

Evaluating the active patterns that leverage `TryParse` yields the following error:

```
/~/fsharp/active-patterns.fsx(4,11): error FS0041: A unique overload for method 'TryParse' could not be determined based on type information prior to this program point. A type annotation may be needed. Candidates: Int32.TryParse(s: ReadOnlySpan<char>, result: byref<int>) : bool, Int32.TryParse(s: string, result: byref<int>) : bool
```

Perhaps this is something that has changed in F# since the article was written?

I figured I would submit a pull request in case it trips up another new user.

Thanks again for this incredible resource!