### PR TITLE
Update 2015-08-20-recursive-types-and-folds.md

### DIFF
--- a/_posts/2015-08-20-recursive-types-and-folds.md
+++ b/_posts/2015-08-20-recursive-types-and-folds.md
@@ -449,7 +449,7 @@ let rec cataGift fBook fChocolate fWrapped fBox fCard gift :'r =
 It's much simpler than the original implementation, and also demonstrates the symmetry between a case constructor like `Wrapped (gift,style)`
 and the corresponding handler `fWrapped (recurse gift,style)`. Which leads us nicely to...
 
-### The relationship between the type constructors and the handlers
+### The relationship between the case constructors and the handlers
 
 Here is the signature for the `cataGift` function. You can see that each case handler function (`fBook`, `fBox`, etc.) has the same pattern:
 an input which contains all the data for that case, and a common output type `'r`.  


### PR DESCRIPTION
This PR changes "type" to "case" in [the section heading](https://fsharpforfunandprofit.com/posts/recursive-types-and-folds/#the-relationship-between-the-type-constructors-and-the-handlers) "The relationship between the type constructors and the handlers".

Marco Rodriguez asked in [this comment](https://fsharpforfunandprofit.com/posts/recursive-types-and-folds/#comment-5022605232) if this use of "type constructor" was a typo.  I think he is correct.