### PR TITLE
Changed Attribute to Match .NET Customs

### DIFF
--- a/content/posts/completeness-anything-csharp-can-do/index.md
+++ b/content/posts/completeness-anything-csharp-can-do/index.md
@@ -219,7 +219,7 @@ let color2:Color = enum 2  // cast from int
 // created from parsing a string
 let color3 = System.Enum.Parse(typeof<Color>,"Green") :?> Color // :?> is a downcast
 
-[<System.FlagsAttribute>]
+[<System.Flags>]
 type FileAccess = | Read=1 | Write=2 | Execute=4
 let fileaccess = FileAccess.Read ||| FileAccess.Write
 ```


### PR DESCRIPTION
Under the Enums section example code, I have changed `FlagsAttribute` to match the .NET Convention of not explicitly writing out the `Attribute` part of an attribute's full name.