### PR TITLE
Added parameter hint causing Error in VSCode

### DIFF
--- a/content/posts/partial-application/index.md
+++ b/content/posts/partial-application/index.md
@@ -176,7 +176,7 @@ However, it is easy enough to create wrappers for them that are more idiomatic. 
 let replace oldStr newStr (s:string) =
   s.Replace(oldValue=oldStr, newValue=newStr)
 
-let startsWith lookFor (s:string) =
+let startsWith (lookFor:string) (s:string) =
   s.StartsWith(lookFor)
 ```
 


### PR DESCRIPTION
In the section "Wrapping BCL functions for partial application", the `startsWith` function currently causes an error in VSCode with Omnisharp installed because it cannot infer the type of the `lookFor` parameter. I have added the type hint to make this error go away. I am using Linux so I am unable to confirm if this is an issue specific to VSCode vs Visual Studio. If you believe this error is specific to VSCode, then I will happily withdraw this PR and try to find a fix in Omnisharp. Thank you!