### PR TITLE
Improve uses of tuple, pair, and triple

### DIFF
--- a/content/posts/elevated-world/index.md
+++ b/content/posts/elevated-world/index.md
@@ -803,7 +803,7 @@ let resultAdd =
 
 Note that we can't just have *one* `add` function in the first list -- we have to have one `add` for every element in the second and third lists!
 
-That could get annoying, so often, a "paird" version of `zip` is used, whereby you don't specify a combining function at all, and just get back a list of pairs instead,
+That could get annoying, so often, a "paired" version of `zip` is used, whereby you don't specify a combining function at all, and just get back a list of pairs instead,
 which you can then process later using `map`.
 This is the same approach as was used in the `combine` functions discussed above, but for `zipList`.
 


### PR DESCRIPTION
I always find it a bit jarring when "tuple" is used to mean a tuple of a specific size like a pair or triple.  Another source of confusion is the difference between the pair and triple types in F# and the common meaning of these two words in English.  This PR improves clarity by removing such ambiguities.

The first two commits are similar, so I will only explain the first one.  The function `addPair x y = x + y` adds a pair in the common English sense but not in the F# type sense.  On the other than, this function adds two things, which is true in both a technical and common language sense, so I think `add2` is a better name.  This also improves the parallel syntax in the resulting line `let add2Opt = Option.lift2 add2`.

The last commit changes all occurrences of "tuple" to "pair", which is what is precisely meant every time "tuple" is used.  A sentence especially improved by this change is [this one](https://raw.githubusercontent.com/swlaschin/fsharpforfunandprofit.com/1dfb7bff06b7ef4c3058e9c56c7edd82bbc2e340/content/posts/elevated-world/index.md#:~:text=Now%20that%20we%20have%20an%20elevated%20tuple%2C%20we%20can%20work%20with%20the%20pair%20in%20any%20way%20we%20want)
> Now that we have an elevated tuple, we can work with the pair in any way we want [...]

...which uses both "tuple" and "pair" but means "pair" in both cases.