### PR TITLE
fix: inconsistent code in enterprise-tic-tac-toe

### DIFF
--- a/content/posts/enterprise-tic-tac-toe/index.md
+++ b/content/posts/enterprise-tic-tac-toe/index.md
@@ -539,10 +539,10 @@ type ValidMovesForPlayerX = PlayerXPos list
 type ValidMovesForPlayerO = PlayerOPos list
 
 type MoveResult =
-    | PlayerXToMove of GameState * ValidMovesForPlayerX
-    | PlayerOToMove of GameState * ValidMovesForPlayerO
-    | GameWon of GameState * Player
-    | GameTied of GameState
+    | PlayerXToMove of ValidMovesForPlayerX
+    | PlayerOToMove of ValidMovesForPlayerO
+    | GameWon of Player
+    | GameTied
 ```
 
 We've replaced the `InProcess` case with two new cases `PlayerXToMove` and `PlayerOToMove`, which I think is actually clearer.


### PR DESCRIPTION
In the text, it is explained that the `GameState` is not going to be part of `MoveResult`, but the accompanying code is inconsistent with the explanation