### PR TITLE
fix: function commentary order

### DIFF
--- a/content/posts/currying/index.md
+++ b/content/posts/currying/index.md
@@ -184,15 +184,17 @@ let multiParamFn (p1:int)(p2:bool)(p3:string)(p4:float)=
    ()   //do nothing
 
 let intermediateFn1 = multiParamFn 42
-   // intermediateFn1 takes a bool
-   // and returns a new function (string -> float -> unit)
+   // intermediateFn1 takes an int
+   // and returns a new function (bool -> string -> float -> unit)
 let intermediateFn2 = intermediateFn1 false
-   // intermediateFn2 takes a string
-   // and returns a new function (float -> unit)
+   // intermediateFn2 takes a bool
+   // and returns a new function (string -> float -> unit)   
 let intermediateFn3 = intermediateFn2 "hello"
-   // intermediateFn3 takes a float
-   // and returns a simple value (unit)
+   // intermediateFn3 takes a string
+   // and returns a new function (float -> unit)
 let finalResult = intermediateFn3 3.141
+   // finalResult takes a float
+   // and returns a simple value (unit)
 ```
 
 The signature of the overall function is:


### PR DESCRIPTION
Comments did not reflect the function flow, saying that `intermediateFn1` did what actually `intermediateFn2` should have, `intermediateFn2` did what `intermediateFn3` should have, etc. `finalResult` did not have any clarification at all, but it should have. 